### PR TITLE
[3860] Dotfiles Update for Repositories: Version 13.0 Generate README file manually

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,12 @@ repos:
       - id: oca-update-pre-commit-excluded-addons
       - id: oca-fix-manifest-website
         args: ["https://www.quartile.co"]
+      - id: oca-gen-addon-readme
+        args:
+          - --addons-dir=.
+          - --branch=13.0
+          - --org-name=qrtl
+          - --repo-name=psc-custom
   - repo: https://github.com/myint/autoflake
     rev: v1.4
     hooks:

--- a/base_company_reporting/static/description/index.html
+++ b/base_company_reporting/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Base Company Reporting</title>
 <style type="text/css">
 

--- a/partner_view_adjust/static/description/index.html
+++ b/partner_view_adjust/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Partner View Adjust</title>
 <style type="text/css">
 

--- a/product_sale_price_security/static/description/index.html
+++ b/product_sale_price_security/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Product Sale Price Security</title>
 <style type="text/css">
 


### PR DESCRIPTION
[3860](https://www.quartile.co/web#id=3860&menu_id=517&cids=3&model=project.task&view_type=form)
#25  was merged without README file because hook for oca-gen-addon-readme is not generated in .pre-commit-config.yaml for odoo 13.0.  So I  generate README file manually and created this PR.